### PR TITLE
Expose provider-backed gateway endpoints

### DIFF
--- a/BACKEND_CONTRACT.md
+++ b/BACKEND_CONTRACT.md
@@ -1,0 +1,180 @@
+# Downtime Gateway API Contract
+
+## Base URL
+Not defined in repository configuration. Deployments should configure `NEXT_PUBLIC_GATEWAY_URL` to the desired Zuplo domain.
+
+## Authentication
+Not required. All routes currently opt into the permissive `anything-goes` CORS policy with no inbound authentication policies.
+
+## Endpoints
+
+### GET /places
+**Request Parameters**
+- `lat` (number, required): Latitude of the origin point.
+- `lng` (number, required): Longitude of the origin point.
+- `radius_m` (number, required): Search radius in meters.
+- `categories` (string, required): Comma-separated list of categories/keywords.
+- `limit` (number, optional, default 20, max 50): Maximum number of places to return.
+- `open_now` (boolean, optional): When provided, filters for places currently open.
+
+**Example Request**
+```
+GET /places?lat=42.3314&lng=-83.0458&radius_m=1000&categories=coffee,cafe&limit=25
+```
+
+**Response Structure**
+Returns a JSON object with provider metadata and the waterfall-normalized places list.
+```json
+{
+  "places": [
+    {
+      "id": "string",
+      "name": "string",
+      "lat": 42.332,
+      "lng": -83.046,
+      "address": "optional formatted address",
+      "categories": ["category", "keywords"],
+      "rating": 4.6,
+      "reviewCount": 128,
+      "priceLevel": 2,
+      "openNow": true,
+      "distanceMeters": 187,
+      "provider": "foursquare",
+      "raw": { "providerSpecific": "payload" }
+    }
+  ],
+  "provider_used": "foursquare",
+  "cache_hit": false
+}
+```
+
+**Provider Logic**
+The provider waterfall tries the following order until results are returned:
+1. OpenStreetMap Photon search (`modules/logic/providers/osm.ts`).
+2. Foursquare Places (`modules/logic/providers/foursquare.ts`).
+3. Yelp Fusion (`modules/logic/providers/yelp.ts`).
+4. Google Places Nearby Search (`modules/logic/providers/google.ts`).
+
+Each provider returns normalized `Place` objects; the orchestrator stops at the first provider that yields results. Failures are logged and the next provider is attempted. Implementation: `modules/logic/api-logic.ts#getPlaces`.
+
+**Error Handling**
+- `400 Bad Request` when required query parameters are missing or invalid.
+- `500 Internal Server Error` when all providers fail or an unexpected error occurs.
+
+---
+
+### GET /geocode
+**Request Parameters**
+- `query` (string, required): Address or place name to geocode.
+
+**Example Request**
+```
+GET /geocode?query=1600+Pennsylvania+Ave+NW+Washington+DC
+```
+
+**Response Structure**
+```json
+{
+  "location": { "lat": 38.8977, "lng": -77.0365 },
+  "address": "1600 Pennsylvania Avenue NW, Washington, DC 20500, USA",
+  "provider": "google"
+}
+```
+
+**Provider Logic**
+1. OpenStreetMap Nominatim (`modules/logic/api-logic.ts#geocode`).
+2. Google Geocoding (fallback when OSM misses and a Google key is configured).
+
+**Error Handling**
+- `400 Bad Request` when `query` is empty.
+- `500 Internal Server Error` when providers fail.
+
+---
+
+### POST /travel-times
+**Request Body**
+```json
+{
+  "origin": { "lat": 42.3314, "lng": -83.0458 },
+  "destinations": [
+    { "id": "gm-1", "lat": 42.3401, "lng": -83.0523 }
+  ]
+}
+```
+
+**Response Structure**
+```json
+{
+  "results": [
+    {
+      "id": "gm-1",
+      "distanceMeters": 1250,
+      "drivingMinutes": 1.5,
+      "walkingMinutes": 15.0,
+      "bikingMinutes": 5.0
+    }
+  ],
+  "provider": "heuristic"
+}
+```
+
+**Provider Logic**
+The handler uses an internal heuristic speed model to approximate travel times by distance (50 km/h driving, 5 km/h walking, 15 km/h biking). Implementation: `modules/logic/api-logic.ts#estimateTravelTimes`.
+
+**Error Handling**
+- `400 Bad Request` for invalid payloads.
+- `405 Method Not Allowed` for non-POST requests.
+- `500 Internal Server Error` for unexpected failures.
+
+---
+
+### GET /test-db
+**Request Parameters**
+- _None_: The handler reads no query string parameters and simply queries Supabase for a single `places` record.
+
+**Example Request**
+```
+GET /test-db
+```
+
+**Response Structure**
+```json
+{
+  "success": true,
+  "sample": [
+    { "id": "<uuid>", "name": "<place name>" }
+  ]
+}
+```
+
+**Provider Logic**
+Direct Supabase read to validate connectivity: `modules/test-db.ts`.
+
+**Error Handling**
+- `500 Internal Server Error` surfaces Supabase error messages when the query fails.
+
+---
+
+## Environment Variables
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `SUPABASEURL` | Supabase project URL used by `/test-db`. | ✅ |
+| `SUPABASEKEY` | Supabase key used by `/test-db`. | ✅ |
+| `FOURSQUARE_API_KEY` | Credential for Foursquare provider. | ⚠️ Required for Foursquare coverage. |
+| `YELP_API_KEY` | Credential for Yelp provider. | ⚠️ Required for Yelp coverage. |
+| `GOOGLE_PLACES_API_KEY` | Credential for Google Places fallback. | ⚠️ Required for Google provider usage. |
+| `GOOGLE_GEOCODING_API_KEY` | Optional dedicated key for geocoding fallback. | ⚠️ Needed if Google geocoding should be available. |
+| `NEXT_PUBLIC_GATEWAY_URL` | Frontend configuration pointing to the deployed gateway. | ✅ for frontend integration |
+
+## Deployment / CORS Notes
+- Every route opts into the `anything-goes` CORS policy allowing all origins.
+- No inbound auth policies or IP allow-lists are configured; Zuplo policies can be layered later if required.
+
+## Code References
+- Route configuration: `config/routes.oas.json`.
+- Places handler: `modules/handlers/places-handler.ts`.
+- Geocode handler: `modules/handlers/geocode-handler.ts`.
+- Travel times handler: `modules/handlers/travel-times-handler.ts`.
+- Provider orchestrator: `modules/logic/api-logic.ts`.
+- Provider adapters: `modules/logic/providers/*.ts`.
+- Utility helpers: `modules/logic/utils.ts`.

--- a/config/routes.oas.json
+++ b/config/routes.oas.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "version": "1.0.0",
-    "title": "My Zuplo API"
+    "title": "Downtime Gateway API"
   },
   "paths": {
     "/test-db": {
@@ -23,7 +23,198 @@
             "inbound": []
           }
         },
-        "operationId": "new-route-4808ebd9"
+        "operationId": "test-db"
+      }
+    },
+    "/places": {
+      "x-zuplo-path": {
+        "pathMode": "open-api"
+      },
+      "get": {
+        "summary": "Get places near a location",
+        "description": "Returns nearby places using the provider waterfall OSM → Foursquare → Yelp → Google.",
+        "operationId": "getPlaces",
+        "x-zuplo-route": {
+          "corsPolicy": "anything-goes",
+          "handler": {
+            "export": "default",
+            "module": "$import(./modules/handlers/places-handler)",
+            "options": {}
+          }
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "number" },
+            "description": "Latitude of the origin point"
+          },
+          {
+            "name": "lng",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "number" },
+            "description": "Longitude of the origin point"
+          },
+          {
+            "name": "radius_m",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "integer", "minimum": 1 },
+            "description": "Search radius in meters"
+          },
+          {
+            "name": "categories",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Comma separated list of categories or keywords"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1, "maximum": 50 },
+            "description": "Maximum number of places to return"
+          },
+          {
+            "name": "open_now",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean" },
+            "description": "Filter to only show places that are currently open"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "places": {
+                      "type": "array",
+                      "items": { "type": "object" }
+                    },
+                    "provider_used": { "type": "string" },
+                    "cache_hit": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/geocode": {
+      "x-zuplo-path": {
+        "pathMode": "open-api"
+      },
+      "get": {
+        "summary": "Geocode an address",
+        "description": "Resolves an address string to coordinates using OSM and Google fallbacks.",
+        "operationId": "geocode",
+        "x-zuplo-route": {
+          "corsPolicy": "anything-goes",
+          "handler": {
+            "export": "default",
+            "module": "$import(./modules/handlers/geocode-handler)",
+            "options": {}
+          }
+        },
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Address or place name to geocode"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/travel-times": {
+      "x-zuplo-path": {
+        "pathMode": "open-api"
+      },
+      "post": {
+        "summary": "Estimate travel times",
+        "description": "Estimates travel times between an origin and multiple destinations.",
+        "operationId": "travelTimes",
+        "x-zuplo-route": {
+          "corsPolicy": "anything-goes",
+          "handler": {
+            "export": "default",
+            "module": "$import(./modules/handlers/travel-times-handler)",
+            "options": {}
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "origin": {
+                    "type": "object",
+                    "properties": {
+                      "lat": { "type": "number" },
+                      "lng": { "type": "number" }
+                    },
+                    "required": ["lat", "lng"]
+                  },
+                  "destinations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "lat": { "type": "number" },
+                        "lng": { "type": "number" }
+                      },
+                      "required": ["id", "lat", "lng"]
+                    }
+                  }
+                },
+                "required": ["origin", "destinations"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
       }
     }
   }

--- a/env.example
+++ b/env.example
@@ -1,2 +1,10 @@
-EXAMPLE_SECRET=👀 What you looking at?
-EXAMPLE_CONFIG=https://twitter.com/zuplo
+# Core provider credentials
+SUPABASEURL=
+SUPABASEKEY=
+FOURSQUARE_API_KEY=
+YELP_API_KEY=
+GOOGLE_PLACES_API_KEY=
+GOOGLE_GEOCODING_API_KEY=
+
+# Frontend integration
+NEXT_PUBLIC_GATEWAY_URL=https://your-zuplo-url.dev

--- a/modules/handlers/geocode-handler.ts
+++ b/modules/handlers/geocode-handler.ts
@@ -1,0 +1,32 @@
+import { geocode } from "../logic/api-logic";
+
+export default async function handler(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const query = url.searchParams.get("query") ?? "";
+
+  try {
+    const result = await geocode(query);
+    return new Response(JSON.stringify(result), {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error("[Gateway] /geocode error", error);
+    const status = error instanceof Error && /cannot be empty/i.test(error.message)
+      ? 400
+      : 500;
+
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  }
+}

--- a/modules/handlers/places-handler.ts
+++ b/modules/handlers/places-handler.ts
@@ -1,0 +1,84 @@
+import { getPlaces } from "../logic/api-logic";
+import type { PlacesQuery } from "../logic/types";
+import { parseCategories } from "../logic/utils";
+
+function parseBoolean(value: string | null): boolean | undefined {
+  if (value === null) return undefined;
+  if (value === "1" || value.toLowerCase() === "true") return true;
+  if (value === "0" || value.toLowerCase() === "false") return false;
+  return undefined;
+}
+
+function buildQuery(url: URL): PlacesQuery {
+  const lat = Number.parseFloat(url.searchParams.get("lat") ?? "");
+  const lng = Number.parseFloat(url.searchParams.get("lng") ?? "");
+  const radiusMeters = Number.parseInt(
+    url.searchParams.get("radius_m") ?? "",
+    10
+  );
+  const categoriesParam = url.searchParams.get("categories") ?? "";
+  const categories = parseCategories(categoriesParam);
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+  const openNow = parseBoolean(url.searchParams.get("open_now"));
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    throw new Error("lat and lng query parameters are required numbers");
+  }
+
+  if (!Number.isFinite(radiusMeters) || radiusMeters <= 0) {
+    throw new Error("radius_m query parameter must be a positive number");
+  }
+
+  if (categories.length === 0) {
+    throw new Error("categories query parameter must contain at least one value");
+  }
+
+  return {
+    lat,
+    lng,
+    radiusMeters,
+    categories,
+    limit,
+    openNow,
+  };
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+
+  try {
+    const query = buildQuery(url);
+    const result = await getPlaces(query);
+
+    return new Response(
+      JSON.stringify({
+        places: result.places,
+        provider_used: result.provider,
+        cache_hit: Boolean(result.cacheHit),
+      }),
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  } catch (error) {
+    console.error("[Gateway] /places error", error);
+    const status = error instanceof Error && /required/.test(error.message)
+      ? 400
+      : 500;
+
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  }
+}

--- a/modules/handlers/travel-times-handler.ts
+++ b/modules/handlers/travel-times-handler.ts
@@ -1,0 +1,47 @@
+import { estimateTravelTimes } from "../logic/api-logic";
+import type { TravelTimesRequest } from "../logic/types";
+
+export default async function handler(request: Request): Promise<Response> {
+  if (request.method !== "POST") {
+    return new Response(
+      JSON.stringify({ error: "Method not allowed" }),
+      {
+        status: 405,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  try {
+    const payload = (await request.json()) as TravelTimesRequest;
+    if (!payload || !payload.origin || !Array.isArray(payload.destinations)) {
+      return new Response(
+        JSON.stringify({ error: "Invalid request body" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const response = estimateTravelTimes(payload);
+    return new Response(JSON.stringify(response), {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error("[Gateway] /travel-times error", error);
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  }
+}

--- a/modules/logic/api-logic.ts
+++ b/modules/logic/api-logic.ts
@@ -1,0 +1,193 @@
+import { searchWithFoursquare } from "./providers/foursquare";
+import { searchWithGoogle } from "./providers/google";
+import { searchWithOsm } from "./providers/osm";
+import { searchWithYelp } from "./providers/yelp";
+import type {
+  GeocodeResult,
+  PlacesQuery,
+  ProviderName,
+  ProviderSearchResult,
+  TravelTimesRequest,
+  TravelTimesResponse,
+} from "./types";
+import { calculateDistanceMeters } from "./utils";
+
+interface WaterfallResult extends ProviderSearchResult {
+  provider: ProviderName;
+}
+
+const providerSequence: ProviderName[] = [
+  "osm",
+  "foursquare",
+  "yelp",
+  "google",
+];
+
+type ProviderSearcher = (
+  query: PlacesQuery
+) => Promise<ProviderSearchResult | null>;
+
+const searchers: Record<ProviderName, ProviderSearcher> = {
+  osm: searchWithOsm,
+  foursquare: searchWithFoursquare,
+  yelp: searchWithYelp,
+  google: searchWithGoogle,
+};
+
+export async function getPlaces(
+  query: PlacesQuery
+): Promise<WaterfallResult> {
+  const errors: Array<{ provider: ProviderName; error: unknown }> = [];
+
+  for (const provider of providerSequence) {
+    const searcher = searchers[provider];
+    try {
+      const result = await searcher(query);
+      if (result && result.places.length > 0) {
+        return {
+          provider,
+          places: result.places,
+          cacheHit: result.cacheHit,
+        };
+      }
+    } catch (error) {
+      console.warn(`[Gateway] Provider ${provider} failed`, error);
+      errors.push({ provider, error });
+    }
+  }
+
+  const error = new Error(
+    `No providers returned results. Failures: ${errors
+      .map((entry) => `${entry.provider}: ${String(entry.error)}`)
+      .join("; ")}`
+  );
+  throw error;
+}
+
+export async function geocode(query: string): Promise<GeocodeResult> {
+  const normalized = query.trim();
+  if (!normalized) {
+    throw new Error("Query cannot be empty");
+  }
+
+  const nominatim = new URL("https://nominatim.openstreetmap.org/search");
+  nominatim.searchParams.set("q", normalized);
+  nominatim.searchParams.set("format", "jsonv2");
+  nominatim.searchParams.set("limit", "1");
+
+  const osmResponse = await fetch(nominatim, {
+    headers: {
+      "User-Agent": "Downtime-Gateway/1.0 (+https://github.com/zuplo)",
+    },
+  });
+
+  if (osmResponse.ok) {
+    const payload = (await osmResponse.json()) as Array<{
+      lat: string;
+      lon: string;
+      display_name: string;
+    }>;
+
+    if (payload.length > 0) {
+      const [result] = payload;
+      return {
+        location: {
+          lat: Number.parseFloat(result.lat),
+          lng: Number.parseFloat(result.lon),
+        },
+        address: result.display_name,
+        provider: "osm",
+      };
+    }
+  }
+
+  const googleKey = (() => {
+    try {
+      return (
+        zuplo.env.GOOGLE_GEOCODING_API_KEY ??
+        zuplo.env.GOOGLE_PLACES_API_KEY ??
+        zuplo.env.GOOGLE_MAPS_API_KEY ??
+        null
+      );
+    } catch (error) {
+      console.warn("[Gateway] Google geocoding key missing", error);
+      return null;
+    }
+  })();
+
+  if (!googleKey) {
+    throw new Error("No geocoding providers returned results");
+  }
+
+  const googleUrl = new URL(
+    "https://maps.googleapis.com/maps/api/geocode/json"
+  );
+  googleUrl.searchParams.set("address", normalized);
+  googleUrl.searchParams.set("key", googleKey);
+
+  const googleResponse = await fetch(googleUrl);
+  if (!googleResponse.ok) {
+    throw new Error(
+      `Google geocode failed with status ${googleResponse.status}`
+    );
+  }
+
+  const googlePayload = (await googleResponse.json()) as {
+    results: Array<{
+      geometry: { location: { lat: number; lng: number } };
+      formatted_address: string;
+    }>;
+    status: string;
+  };
+
+  if (googlePayload.status !== "OK" || googlePayload.results.length === 0) {
+    throw new Error(
+      `Google geocode returned status ${googlePayload.status}`
+    );
+  }
+
+  const [googleResult] = googlePayload.results;
+  return {
+    location: googleResult.geometry.location,
+    address: googleResult.formatted_address,
+    provider: "google",
+  };
+}
+
+export function estimateTravelTimes(
+  request: TravelTimesRequest
+): TravelTimesResponse {
+  const AVERAGE_SPEEDS = {
+    driving: 50_000 / 60, // 50 km/h in meters per minute
+    walking: 5_000 / 60, // 5 km/h in meters per minute
+    biking: 15_000 / 60, // 15 km/h in meters per minute
+  } as const;
+
+  const results = request.destinations.map((destination) => {
+    const distanceMeters = calculateDistanceMeters(
+      request.origin.lat,
+      request.origin.lng,
+      destination.lat,
+      destination.lng
+    );
+
+    return {
+      id: destination.id,
+      distanceMeters,
+      drivingMinutes: Number.parseFloat(
+        (distanceMeters / AVERAGE_SPEEDS.driving).toFixed(2)
+      ),
+      walkingMinutes: Number.parseFloat(
+        (distanceMeters / AVERAGE_SPEEDS.walking).toFixed(2)
+      ),
+      bikingMinutes: Number.parseFloat(
+        (distanceMeters / AVERAGE_SPEEDS.biking).toFixed(2)
+      ),
+    };
+  });
+
+  return {
+    results,
+    provider: "heuristic",
+  };
+}

--- a/modules/logic/providers/foursquare.ts
+++ b/modules/logic/providers/foursquare.ts
@@ -1,0 +1,111 @@
+import { annotateDistance } from "../utils";
+import type { Place, PlacesQuery, ProviderSearchResult } from "../types";
+
+const BASE_URL = "https://api.foursquare.com/v3/places/search";
+
+interface FoursquarePlace {
+  fsq_id: string;
+  name: string;
+  location: {
+    address?: string;
+    locality?: string;
+    region?: string;
+    country?: string;
+    postcode?: string;
+    formatted_address?: string;
+    latitude: number;
+    longitude: number;
+  };
+  categories?: Array<{
+    id: number;
+    name: string;
+  }>;
+  rating?: number;
+  popularity?: number;
+  closed_bucket?: string;
+}
+
+interface FoursquareResponse {
+  results: FoursquarePlace[];
+}
+
+function getApiKey(): string | null {
+  try {
+    return zuplo.env.FOURSQUARE_API_KEY ?? null;
+  } catch (error) {
+    console.warn("[Foursquare] API key not configured", error);
+    return null;
+  }
+}
+
+export async function searchWithFoursquare(
+  query: PlacesQuery
+): Promise<ProviderSearchResult | null> {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return null;
+  }
+
+  const { lat, lng, categories, radiusMeters, limit = 20, openNow } = query;
+  const url = new URL(BASE_URL);
+  url.searchParams.set("ll", `${lat},${lng}`);
+  url.searchParams.set("radius", Math.min(radiusMeters, 100_000).toString());
+  url.searchParams.set("limit", Math.min(limit, 50).toString());
+  if (categories.length > 0) {
+    url.searchParams.set("categories", categories.join(","));
+  }
+  if (openNow !== undefined) {
+    url.searchParams.set("open_now", openNow ? "true" : "false");
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: "application/json",
+      Authorization: apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Foursquare search failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as FoursquareResponse;
+  const places: Place[] = (payload.results ?? []).map((result) => {
+    const address =
+      result.location.formatted_address ??
+      [
+        result.location.address,
+        result.location.locality,
+        result.location.region,
+        result.location.country,
+        result.location.postcode,
+      ]
+        .filter(Boolean)
+        .join(", ");
+
+    return annotateDistance(
+      {
+        id: result.fsq_id,
+        name: result.name,
+        lat: result.location.latitude,
+        lng: result.location.longitude,
+        address,
+        categories: (result.categories ?? []).map((category) => category.name),
+        rating: result.rating,
+        provider: "foursquare",
+        raw: result,
+      },
+      lat,
+      lng
+    );
+  });
+
+  if (places.length === 0) {
+    return null;
+  }
+
+  return {
+    provider: "foursquare",
+    places,
+  };
+}

--- a/modules/logic/providers/google.ts
+++ b/modules/logic/providers/google.ts
@@ -1,0 +1,100 @@
+import { annotateDistance } from "../utils";
+import type { Place, PlacesQuery, ProviderSearchResult } from "../types";
+
+const BASE_URL = "https://maps.googleapis.com/maps/api/place/nearbysearch/json";
+
+interface GooglePlace {
+  place_id: string;
+  name: string;
+  geometry: {
+    location: {
+      lat: number;
+      lng: number;
+    };
+  };
+  vicinity?: string;
+  business_status?: string;
+  opening_hours?: {
+    open_now?: boolean;
+  };
+  rating?: number;
+  user_ratings_total?: number;
+  price_level?: number;
+  types?: string[];
+  formatted_address?: string;
+}
+
+interface GoogleResponse {
+  results: GooglePlace[];
+  status: string;
+}
+
+function getApiKey(): string | null {
+  try {
+    return zuplo.env.GOOGLE_PLACES_API_KEY ?? zuplo.env.GOOGLE_MAPS_API_KEY ?? null;
+  } catch (error) {
+    console.warn("[Google Places] API key not configured", error);
+    return null;
+  }
+}
+
+export async function searchWithGoogle(
+  query: PlacesQuery
+): Promise<ProviderSearchResult | null> {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return null;
+  }
+
+  const { lat, lng, categories, radiusMeters, limit = 20, openNow } = query;
+  const url = new URL(BASE_URL);
+  url.searchParams.set("location", `${lat},${lng}`);
+  url.searchParams.set("radius", Math.min(radiusMeters, 50_000).toString());
+  if (categories.length > 0) {
+    url.searchParams.set("keyword", categories.join(" "));
+  }
+  if (openNow !== undefined) {
+    url.searchParams.set("opennow", openNow ? "true" : "false");
+  }
+  url.searchParams.set("key", apiKey);
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    throw new Error(`Google Places search failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as GoogleResponse;
+  if (payload.status !== "OK" && payload.status !== "ZERO_RESULTS") {
+    throw new Error(`Google Places search returned status ${payload.status}`);
+  }
+
+  const places: Place[] = (payload.results ?? []).slice(0, limit).map((result) =>
+    annotateDistance(
+      {
+        id: result.place_id,
+        name: result.name,
+        lat: result.geometry.location.lat,
+        lng: result.geometry.location.lng,
+        address: result.formatted_address ?? result.vicinity,
+        categories: result.types,
+        rating: result.rating,
+        reviewCount: result.user_ratings_total,
+        priceLevel: result.price_level,
+        openNow: result.opening_hours?.open_now,
+        provider: "google",
+        raw: result,
+      },
+      lat,
+      lng
+    )
+  );
+
+  if (places.length === 0) {
+    return null;
+  }
+
+  return {
+    provider: "google",
+    places,
+  };
+}

--- a/modules/logic/providers/osm.ts
+++ b/modules/logic/providers/osm.ts
@@ -1,0 +1,88 @@
+import { annotateDistance, withUserAgent } from "../utils";
+import type { Place, PlacesQuery, ProviderSearchResult } from "../types";
+
+interface PhotonFeature {
+  geometry: {
+    coordinates: [number, number];
+  };
+  properties: {
+    osm_id: number;
+    osm_type: string;
+    name?: string;
+    street?: string;
+    housenumber?: string;
+    city?: string;
+    state?: string;
+    country?: string;
+    postcode?: string;
+    type?: string;
+    osm_key?: string;
+    osm_value?: string;
+  };
+}
+
+interface PhotonResponse {
+  features: PhotonFeature[];
+}
+
+export async function searchWithOsm(
+  query: PlacesQuery
+): Promise<ProviderSearchResult | null> {
+  const { lat, lng, categories, limit = 20 } = query;
+  const search = categories.length > 0 ? categories.join(" ") : "amenity";
+  const url = new URL("https://photon.komoot.io/api/");
+  url.searchParams.set("lat", lat.toString());
+  url.searchParams.set("lon", lng.toString());
+  url.searchParams.set("q", search);
+  url.searchParams.set("limit", Math.min(limit, 50).toString());
+  url.searchParams.set("lang", "en");
+
+  const response = await fetch(url.toString(), withUserAgent());
+  if (!response.ok) {
+    throw new Error(`OSM search failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as PhotonResponse;
+  const places: Place[] = (payload.features ?? []).map((feature) => {
+    const [featureLng, featureLat] = feature.geometry.coordinates;
+    const { properties } = feature;
+
+    const addressParts = [
+      properties.housenumber && properties.street
+        ? `${properties.housenumber} ${properties.street}`
+        : properties.street,
+      properties.city,
+      properties.state,
+      properties.country,
+      properties.postcode,
+    ].filter(Boolean);
+
+    return annotateDistance(
+      {
+        id: `${properties.osm_type}:${properties.osm_id}`,
+        name: properties.name ?? properties.type ?? "Unnamed place",
+        lat: featureLat,
+        lng: featureLng,
+        address: addressParts.join(", "),
+        categories: [
+          properties.type,
+          properties.osm_key,
+          properties.osm_value,
+        ].filter(Boolean) as string[],
+        provider: "osm",
+        raw: feature,
+      },
+      lat,
+      lng
+    );
+  });
+
+  if (places.length === 0) {
+    return null;
+  }
+
+  return {
+    provider: "osm",
+    places,
+  };
+}

--- a/modules/logic/providers/yelp.ts
+++ b/modules/logic/providers/yelp.ts
@@ -1,0 +1,122 @@
+import { annotateDistance } from "../utils";
+import type { Place, PlacesQuery, ProviderSearchResult } from "../types";
+
+const BASE_URL = "https://api.yelp.com/v3/businesses/search";
+
+interface YelpBusiness {
+  id: string;
+  name: string;
+  coordinates: {
+    latitude: number;
+    longitude: number;
+  };
+  location: {
+    address1?: string;
+    city?: string;
+    state?: string;
+    country?: string;
+    zip_code?: string;
+    display_address?: string[];
+  };
+  categories?: Array<{
+    alias: string;
+    title: string;
+  }>;
+  rating?: number;
+  review_count?: number;
+  price?: string;
+  is_closed?: boolean;
+  display_phone?: string;
+  url?: string;
+}
+
+interface YelpResponse {
+  businesses: YelpBusiness[];
+}
+
+function getApiKey(): string | null {
+  try {
+    return zuplo.env.YELP_API_KEY ?? null;
+  } catch (error) {
+    console.warn("[Yelp] API key not configured", error);
+    return null;
+  }
+}
+
+export async function searchWithYelp(
+  query: PlacesQuery
+): Promise<ProviderSearchResult | null> {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return null;
+  }
+
+  const { lat, lng, categories, radiusMeters, limit = 20, openNow } = query;
+  const url = new URL(BASE_URL);
+  url.searchParams.set("latitude", lat.toString());
+  url.searchParams.set("longitude", lng.toString());
+  url.searchParams.set("radius", Math.min(radiusMeters, 40_000).toString());
+  url.searchParams.set("limit", Math.min(limit, 50).toString());
+  if (categories.length > 0) {
+    url.searchParams.set("categories", categories.join(","));
+  }
+  if (openNow !== undefined) {
+    url.searchParams.set("open_now", openNow ? "true" : "false");
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Yelp search failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as YelpResponse;
+  const places: Place[] = (payload.businesses ?? []).map((business) => {
+    const address =
+      (business.location.display_address ?? []).join(", ") ||
+      [
+        business.location.address1,
+        business.location.city,
+        business.location.state,
+        business.location.country,
+        business.location.zip_code,
+      ]
+        .filter(Boolean)
+        .join(", ");
+
+    return annotateDistance(
+      {
+        id: business.id,
+        name: business.name,
+        lat: business.coordinates.latitude,
+        lng: business.coordinates.longitude,
+        address,
+        categories: (business.categories ?? []).map((category) => category.title),
+        rating: business.rating,
+        reviewCount: business.review_count,
+        priceLevel: business.price ? business.price.length : undefined,
+        openNow: business.is_closed === undefined ? undefined : !business.is_closed,
+        phone: business.display_phone,
+        website: business.url,
+        provider: "yelp",
+        raw: business,
+      },
+      lat,
+      lng
+    );
+  });
+
+  if (places.length === 0) {
+    return null;
+  }
+
+  return {
+    provider: "yelp",
+    places,
+  };
+}

--- a/modules/logic/types.ts
+++ b/modules/logic/types.ts
@@ -1,0 +1,75 @@
+export type ProviderName = "osm" | "foursquare" | "yelp" | "google";
+
+export interface Place {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  address?: string;
+  categories?: string[];
+  rating?: number;
+  reviewCount?: number;
+  priceLevel?: number;
+  phone?: string;
+  website?: string;
+  distanceMeters?: number;
+  openNow?: boolean;
+  provider?: ProviderName;
+  raw?: unknown;
+}
+
+export interface PlacesQuery {
+  lat: number;
+  lng: number;
+  radiusMeters: number;
+  categories: string[];
+  limit?: number;
+  openNow?: boolean;
+}
+
+export interface ProviderSearchResult {
+  provider: ProviderName;
+  places: Place[];
+  cacheHit?: boolean;
+}
+
+export interface GeocodeResult {
+  location: {
+    lat: number;
+    lng: number;
+  };
+  address?: string;
+  provider: ProviderName;
+}
+
+export interface TravelTimesRequest {
+  origin: {
+    lat: number;
+    lng: number;
+  };
+  destinations: Array<{
+    id: string;
+    lat: number;
+    lng: number;
+  }>;
+}
+
+export interface TravelTimeEstimate {
+  id: string;
+  drivingMinutes?: number;
+  walkingMinutes?: number;
+  bikingMinutes?: number;
+  distanceMeters: number;
+}
+
+export interface TravelTimesResponse {
+  results: TravelTimeEstimate[];
+  provider: "heuristic" | ProviderName;
+}
+
+export class ProviderError extends Error {
+  constructor(message: string, public provider: ProviderName) {
+    super(message);
+    this.name = "ProviderError";
+  }
+}

--- a/modules/logic/utils.ts
+++ b/modules/logic/utils.ts
@@ -1,0 +1,63 @@
+import type { Place } from "./types";
+
+const EARTH_RADIUS_METERS = 6371_000;
+
+export function parseCategories(categories: string): string[] {
+  return categories
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export function calculateDistanceMeters(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number
+): number {
+  const toRadians = (value: number) => (value * Math.PI) / 180;
+
+  const dLat = toRadians(lat2 - lat1);
+  const dLng = toRadians(lng2 - lng1);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2)) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return Math.round(EARTH_RADIUS_METERS * c);
+}
+
+export function annotateDistance(
+  place: Place,
+  originLat: number,
+  originLng: number
+): Place {
+  if (Number.isFinite(place.lat) && Number.isFinite(place.lng)) {
+    place.distanceMeters = calculateDistanceMeters(
+      originLat,
+      originLng,
+      place.lat,
+      place.lng
+    );
+  }
+  return place;
+}
+
+export function withUserAgent(init?: RequestInit): RequestInit {
+  const headers = new Headers(init?.headers ?? {});
+  if (!headers.has("User-Agent")) {
+    headers.set(
+      "User-Agent",
+      "Downtime-Gateway/1.0 (+https://github.com/zuplo/downtime-gateway)"
+    );
+  }
+  return {
+    ...init,
+    headers,
+  };
+}


### PR DESCRIPTION
## Summary
- add Zuplo route definitions for /places, /geocode, and /travel-times
- implement handler and provider waterfall logic for places, geocode, and travel time estimation
- refresh backend contract documentation and environment variable templates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e47711f2948323b0520e1f1bfb909f