### PR TITLE
Fix Yelp provider merge conflict

### DIFF
--- a/modules/logic/providers/yelp.ts
+++ b/modules/logic/providers/yelp.ts
@@ -1,9 +1,9 @@
 import { normalizeYelp, type Place } from "../normalizer";
 import { withUserAgent } from "../utils";
-import type { EnvSource } from "../env";
+import { readEnvValue, type EnvSource } from "../env";
 
 declare const zuplo: any;
-const YELP_API_KEY: string | null = zuplo.env.YELP_API_KEY ?? null;
+const YELP_API_KEY: string | null = zuplo?.env?.YELP_API_KEY ?? null;
 
 const BASE_URL = "https://api.yelp.com/v3/businesses/search";
 
@@ -16,27 +16,31 @@ export interface YelpQuery {
   open_now?: boolean;
 }
 
-function getApiKey(): string | null {
+function getApiKey(env?: EnvSource): string | null {
   try {
     const key = YELP_API_KEY;
     try {
-      console.log('[Yelp Provider] Key present:', Boolean(key));
-      console.log('[Yelp Provider] Key length:', key ? String(key).length : 0);
+      console.log("[Yelp Provider] Key present:", Boolean(key));
+      console.log("[Yelp Provider] Key length:", key ? String(key).length : 0);
     } catch (e) {
       // ignore logging failures
     }
-    return key;
+    if (key) {
+      return key;
+    }
   } catch (error) {
-<<<<<<< Updated upstream
     console.warn("[Yelp] API key not configured", error);
-=======
-    console.warn('[Yelp] API key not configured', error);
-    return null;
->>>>>>> Stashed changes
   }
+
+  const envKey = readEnvValue(env, "YELP_API_KEY");
+  if (envKey) {
+    return envKey;
+  }
+
   if (typeof process !== "undefined" && process.env?.YELP_API_KEY) {
     return process.env.YELP_API_KEY;
   }
+
   return null;
 }
 
@@ -50,7 +54,6 @@ export async function searchWithYelp(
   }
 
   const url = new URL(BASE_URL);
-<<<<<<< Updated upstream
   url.searchParams.set("latitude", query.lat.toString());
   url.searchParams.set("longitude", query.lng.toString());
   url.searchParams.set("radius", Math.min(query.radius_m, 40_000).toString());
@@ -74,74 +77,10 @@ export async function searchWithYelp(
   if (!response.ok) {
     console.warn(
       `[Yelp] search failed with status ${response.status}: ${response.statusText}`
-=======
-  url.searchParams.set('latitude', lat.toString());
-  url.searchParams.set('longitude', lng.toString());
-  url.searchParams.set('radius', Math.min(radiusMeters, 40_000).toString());
-  url.searchParams.set('limit', Math.min(limit, 50).toString());
-  if (categories.length > 0) {
-    url.searchParams.set('categories', categories.join(','));
-  }
-  if (openNow !== undefined) {
-    url.searchParams.set('open_now', openNow ? 'true' : 'false');
-  }
-
-  const response = await fetch(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      Accept: 'application/json',
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Yelp search failed with status ${response.status}`);
-  }
-
-  const payload = (await response.json()) as YelpResponse;
-  const places: Place[] = (payload.businesses ?? []).map((business) => {
-    const address =
-      (business.location.display_address ?? []).join(', ') ||
-      [
-        business.location.address1,
-        business.location.city,
-        business.location.state,
-        business.location.country,
-        business.location.zip_code,
-      ]
-        .filter(Boolean)
-        .join(', ');
-
-    return annotateDistance(
-      {
-        id: business.id,
-        name: business.name,
-        lat: business.coordinates.latitude,
-        lng: business.coordinates.longitude,
-        address,
-        categories: (business.categories ?? []).map((category) => category.title),
-        rating: business.rating,
-        reviewCount: business.review_count,
-        priceLevel: business.price ? business.price.length : undefined,
-        openNow: business.is_closed === undefined ? undefined : !business.is_closed,
-        phone: business.display_phone,
-        website: business.url,
-        provider: 'yelp',
-        raw: business,
-      },
-      lat,
-      lng
->>>>>>> Stashed changes
     );
     return [];
   }
 
-<<<<<<< Updated upstream
   const payload = (await response.json()) as { businesses?: unknown[] };
   return normalizeYelp(payload.businesses ?? []);
-=======
-  return {
-    provider: 'yelp',
-    places,
-  };
->>>>>>> Stashed changes
 }


### PR DESCRIPTION
## Summary
- resolve leftover merge conflict markers in the Yelp provider
- restore the query construction and normalization logic for Yelp searches
- add resilient API key lookup that falls back to provided environment values

## Testing
- npm test *(fails: project does not define any tests in /tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e55de1f3c88323b9a48657a8ee4727